### PR TITLE
Fix slight horizontal overflow

### DIFF
--- a/components/carousel.js
+++ b/components/carousel.js
@@ -32,6 +32,7 @@ const styles = theme => ({
     },
     cardCarousel: {
         display: 'flex',
+	margin: '2px',
     },
     card: {
         maxWidth: 335,

--- a/components/quotes.js
+++ b/components/quotes.js
@@ -116,7 +116,7 @@ class Quotes extends React.Component {
   
       return (
         <div className={classes.root}>
-          <Grid container spacing={16}> 
+          <Grid container> 
           {testimonials.map((step, index) => (
             <Grid key={step.label} item xs={4}>
               <div className={classes.paperRoot}>


### PR DESCRIPTION
Carousel and quotes introduce a slight horizontal overflow on the main page. It looks like this is due to margins on the material design elements.
This creates a horizontal scrollbar which is a slight annoyance:

![2019-01-31-200722_1760x1332_scrot](https://user-images.githubusercontent.com/10215173/52098465-b2671b80-2594-11e9-9e92-707dd70cadb3.png)

PR just adds margins to fix this. Relies on #1.