### PR TITLE
Allow static site builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,3 +84,6 @@ typings/
 
 # DynamoDB Local files
 .dynamodb/
+
+# Static output
+out

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  exportPathMap: function() {
+    return {
+      '/': { page: '/' }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "dev": "next",
     "build": "next build",
-    "start": "next start"
+    "start": "next start",
+    "export": "next export"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Adds the ability to statically build the site using next.js.

Run `npm run build` followed by `npm run export`. Static files will be available in `./out`.